### PR TITLE
feat/#18: 도착 확인 API 서비스 로직 및 에러 코드 적용

### DIFF
--- a/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/controller/RoomMemberController.java
+++ b/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/controller/RoomMemberController.java
@@ -5,6 +5,7 @@ import com.example.demo.domain.room_member.dto.request.AssignRolesRequestDto;
 import com.example.demo.domain.room_member.dto.response.AssignRolesResponseDto;
 import com.example.demo.domain.room_member.dto.response.ParticipantResponseDto;
 import com.example.demo.domain.room_member.dto.response.PhotoUploadResponseDto;
+import com.example.demo.domain.room_member.service.RoomMemberService;
 import com.example.demo.global.config.SwaggerConfig;
 import com.example.demo.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,6 +23,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Tag(name = "Room Member", description = "방 참가자 관련 API")
 public class RoomMemberController {
+    private final RoomMemberService roomMemberService;
 
     @PatchMapping("/roles")
     @Operation(summary = "팀 배정", description = "방장 전용 - 마지막에 한번에 보내는 플로우로 생각해봤습니다")
@@ -48,15 +50,21 @@ public class RoomMemberController {
     }
 
     @PatchMapping("/participants/{userId}/arrival")
-    @Operation(summary = "도착으로 변경", description = "방장 전용")
+    @Operation(summary = "도착으로 변경", description = "방장 전용 - 대기방에 있는 참여자의 도착 여부를 변경합니다.")
     @SwaggerConfig.ApiErrorExamples({
-            ErrorCode.RESOURCE_NOT_FOUND,
-            ErrorCode.FORBIDDEN
+            ErrorCode.ROOM_NOT_FOUND,
+            ErrorCode.ROOM_MEMBER_NOT_FOUND,
+            ErrorCode.ONLY_HOST_ALLOWED,
+            ErrorCode.ROOM_NOT_IN_WAITING_STATUS
     })
     public ApiResponse<Void> updateArrival(
             @Parameter(description = "방 ID") @PathVariable Long roomId,
-            @Parameter(description = "사용자 ID") @PathVariable Long userId) {
-        // TODO: 구현 필요
+            @Parameter(description = "도착으로 변경할 참가자의 사용자 ID") @PathVariable Long userId) {
+        // TODO: 실제 인증 시스템 연동 후 hostUserId를 실제 인증된 사용자 ID로 변경
+        Long hostUserId = 1L; // 임시로 1L 사용 (인증 구현 후 수정 필요)
+        
+        roomMemberService.markAsArrived(roomId, userId, hostUserId);
+        
         return ApiResponse.success(null);
     }
 
@@ -74,7 +82,7 @@ public class RoomMemberController {
     }
 
     @PatchMapping("/participants/{userId}/capture")
-    @Operation(summary = "도독 검거")
+    @Operation(summary = "도둑 검거")
     @SwaggerConfig.ApiErrorExamples({
             ErrorCode.RESOURCE_NOT_FOUND
     })
@@ -86,7 +94,7 @@ public class RoomMemberController {
     }
 
     @PatchMapping("/participants/{userId}/release")
-    @Operation(summary = "탈옥", description = "도독이 본인것만")
+    @Operation(summary = "탈옥", description = "도둑이 본인것만")
     @SwaggerConfig.ApiErrorExamples({
             ErrorCode.RESOURCE_NOT_FOUND,
             ErrorCode.FORBIDDEN

--- a/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/entity/RoomMember.java
+++ b/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/entity/RoomMember.java
@@ -44,4 +44,13 @@ public class RoomMember extends BaseEntity {
 
     @Column(name = "caught_at")
     private LocalDateTime caughtAt;
+
+    @Column(name = "is_arrived", nullable = false)
+    @Builder.Default
+    private Boolean isArrived = false;
+
+    public void updateToArrived() {
+        // JoinStatus를 VERIFIED(도착 완료)로 변경
+        this.joinStatus = com.example.demo.domain.room_member.entity.enums.JoinStatus.VERIFIED;
+    }
 }

--- a/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/repository/RoomMemberRepository.java
+++ b/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/repository/RoomMemberRepository.java
@@ -1,0 +1,10 @@
+package com.example.demo.domain.room_member.repository;
+
+import com.example.demo.domain.room_member.entity.RoomMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
+    // 특정 방의 특정 유저 정보를 조회
+    Optional<RoomMember> findByRoom_IdAndUser_Id(Long roomId, Long userId);
+}

--- a/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/service/RoomMemberService.java
+++ b/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/service/RoomMemberService.java
@@ -1,0 +1,45 @@
+package com.example.demo.domain.room_member.service;
+
+import com.example.demo.domain.room.entity.Room;
+import com.example.demo.domain.room.entity.enums.RoomStatus;
+import com.example.demo.domain.room.repository.RoomRepository;
+import com.example.demo.domain.room_member.entity.RoomMember;
+import com.example.demo.domain.room_member.repository.RoomMemberRepository;
+import com.example.demo.global.exception.BusinessException;
+import com.example.demo.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RoomMemberService {
+
+    private final RoomMemberRepository roomMemberRepository;
+    private final RoomRepository roomRepository;
+
+    @Transactional
+    public void markAsArrived(Long roomId, Long targetUserId, Long hostUserId) {
+        // 1. 방 존재 여부 확인
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        // 2. 방 상태 확인: WAITING 상태일 때만 도착 확인 가능
+        if (room.getStatus() != RoomStatus.WAITING) {
+            throw new BusinessException(ErrorCode.ROOM_NOT_IN_WAITING_STATUS);
+        }
+
+        // 3. 권한 확인: 요청자가 방장인지 확인
+        if (!room.getHost().getId().equals(hostUserId)) {
+            throw new BusinessException(ErrorCode.ONLY_HOST_ALLOWED);
+        }
+
+        // 4. 대상 참가자 존재 확인
+        RoomMember targetMember = roomMemberRepository.findByRoom_IdAndUser_Id(roomId, targetUserId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_MEMBER_NOT_FOUND));
+
+        // 5. 도착 상태 업데이트
+        targetMember.updateToArrived();
+    }
+}

--- a/Hackathon-team5/src/main/java/com/example/demo/global/exception/ErrorCode.java
+++ b/Hackathon-team5/src/main/java/com/example/demo/global/exception/ErrorCode.java
@@ -25,10 +25,15 @@ public enum ErrorCode {
 
     // 리소스 에러들
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "RESOURCE_001", "요청한 리소스를 찾을 수 없습니다."),
+    ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "RESOURCE_002", "방을 찾을 수 없습니다."),
+    ROOM_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "RESOURCE_003", "방 참가자를 찾을 수 없습니다."),
 
     // 충돌 오류
-    CONCURRENCY_CONFLICT(HttpStatus.CONFLICT, "CONFLICT_001", "요청이 다른 사용자와 충돌했습니다. 페이지를 새로고침 후 다시 시도해주세요.");
-
+    CONCURRENCY_CONFLICT(HttpStatus.CONFLICT, "CONFLICT_001", "요청이 다른 사용자와 충돌했습니다. 페이지를 새로고침 후 다시 시도해주세요."),
+    
+    // 비즈니스 로직 에러들
+    ONLY_HOST_ALLOWED(HttpStatus.FORBIDDEN, "BUSINESS_001", "방장만 접근할 수 있습니다."),
+    ROOM_NOT_IN_WAITING_STATUS(HttpStatus.BAD_REQUEST, "BUSINESS_002", "대기 중인 방에서만 가능한 작업입니다.");
 
 
     // TODO: 비즈니스 로직 개발하면서 필요한 에러코드들 추가


### PR DESCRIPTION
## 🔗 관련 이슈

#18

---

## 📌 PR 요약

대기방에서 방장이 참여자의 도착 여부를 확인하고 상태를 변경하는 API 구현했습니다.

---

## 📑 작업 내용

1. **방장 전용 도착 확인 로직 구현**
   - `RoomMemberService.markAsArrived()` 메서드를 통해 참여자의 상태를 `VERIFIED`로 변경합니다.
2. **비즈니스 예외 처리 및 검증 강화**
   - 방 존재 여부(`ROOM_NOT_FOUND`) 및 참여자 존재 여부(`ROOM_MEMBER_NOT_FOUND`)를 검증합니다.
   - 요청자가 실제 방장인지 확인하는 권한 로직(`ONLY_HOST_ALLOWED`)을 적용했습니다.
   - 방 상태가 `WAITING`(대기 중)일 때만 도착 확인이 가능하도록 제한했습니다. (`ROOM_NOT_IN_WAITING_STATUS`)
3. **엔티티 비즈니스 메서드 추가**
   - `RoomMember` 엔티티 내부에 상태 변경 로직(`updateToArrived`)을 캡슐화하여 구현했습니다.

---

## 스크린샷 (선택)

---

## 💡 추가 참고 사항

1. **임시 인증 처리**: 현재 인증 시스템 연동 전이므로 컨트롤러에서 `hostUserId`를 임시로 `1L`로 고정하여 테스트했습니다. 추후 Security/JWT 도입 시 수정이 필요합니다.
2. **Dirty Checking**: JPA의 변경 감지 기능을 활용하여 별도의 리포지토리 저장 호출 없이 트랜잭션 종료 시점에 업데이트가 반영되도록 설계했습니다.