### PR TITLE
feat/#22: 대기방 참여자 목록 및 도착 상태 조회 API 구현

### DIFF
--- a/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/controller/RoomMemberController.java
+++ b/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/controller/RoomMemberController.java
@@ -43,10 +43,12 @@ public class RoomMemberController {
     @SwaggerConfig.ApiErrorExamples({
             ErrorCode.RESOURCE_NOT_FOUND
     })
-    public ApiResponse<List<ParticipantResponseDto>> getParticipants(
+    public ApiResponse<ParticipantResponseDto> getParticipants(
             @Parameter(description = "방 ID") @PathVariable Long roomId) {
         // TODO: 구현 필요
-        return ApiResponse.success(List.of());
+        ParticipantResponseDto response = roomMemberService.getParticipantsStatus(roomId);
+
+        return ApiResponse.success(response);
     }
 
     @PatchMapping("/participants/{userId}/arrival")

--- a/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/converter/RoomMemberConverter.java
+++ b/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/converter/RoomMemberConverter.java
@@ -1,0 +1,28 @@
+package com.example.demo.domain.room_member.converter;
+
+import com.example.demo.domain.room_member.dto.response.AssignRolesResponseDto;
+import com.example.demo.domain.room_member.dto.response.ParticipantResponseDto;
+import com.example.demo.domain.room_member.entity.RoomMember;
+import com.example.demo.domain.room_member.entity.enums.JoinStatus;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class RoomMemberConverter {
+
+
+    public ParticipantResponseDto toParticipantResponseDto(Long roomId, List<RoomMember> roomMembers) {
+        List<AssignRolesResponseDto.ParticipantInfo> infoList = roomMembers.stream()
+                .map(member -> AssignRolesResponseDto.ParticipantInfo.builder()
+                        .userId(member.getUser().getId())
+                        .nickname(member.getUser().getNickname())
+                        .role(member.getRole() != null ? member.getRole().name() : "NONE")
+                        .isArrived(member.getJoinStatus() == JoinStatus.VERIFIED)
+                        .build())
+                .collect(Collectors.toList());
+
+        return new ParticipantResponseDto(roomId, infoList);
+    }
+}

--- a/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/repository/RoomMemberRepository.java
+++ b/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/repository/RoomMemberRepository.java
@@ -2,9 +2,15 @@ package com.example.demo.domain.room_member.repository;
 
 import com.example.demo.domain.room_member.entity.RoomMember;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 import java.util.Optional;
 
 public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
+
+    // 특정 방의 모든 참여자 목록을 조회
+    List<RoomMember> findAllByRoom_Id(Long roomId);
+
     // 특정 방의 특정 유저 정보를 조회
     Optional<RoomMember> findByRoom_IdAndUser_Id(Long roomId, Long userId);
 }


### PR DESCRIPTION
## 🔗 관련 이슈
#22

---

## 📌 PR 요약
대기방 내 참여자들의 역할 및 도착 여부를 실시간으로 확인할 수 있는 전체 목록 조회 API를 구현했습니다.

---

## 📑 작업 내용
1. **조회 로직 구현**
   - `RoomMemberRepository`에 `findAllByRoom_Id`를 추가하여 특정 방의 모든 참여자 데이터를 가져오도록 했습니다.
2. **데이터 변환(Converter) 적용**
   - 엔티티(`RoomMember`)를 기존 DTO 구조(`ParticipantResponseDto`)에 맞게 변환하는 로직을 구현했습니다.
   - `JoinStatus.VERIFIED` 상태를 프론트엔드에서 사용하기 편하도록 `isArrived: true/false`로 매핑했습니다.
3. **타입 에러 수정 및 안정화**
   - 컨트롤러의 리턴 타입을 `List`가 아닌 단일 DTO 객체로 수정하여 발생하던 타입 불일치 오류를 해결했습니다.

---

## 💡 테스트 결과
