### PR TITLE
feat/#32: 도둑 검거 기능 및 경찰별 카운트 로직 구현

### DIFF
--- a/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/controller/RoomMemberController.java
+++ b/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/controller/RoomMemberController.java
@@ -113,13 +113,23 @@ public class RoomMemberController {
     @PatchMapping("/participants/{userId}/capture")
     @Operation(summary = "도둑 검거")
     @SwaggerConfig.ApiErrorExamples({
-            ErrorCode.RESOURCE_NOT_FOUND
-    })
-    public ApiResponse<Void> captureThief(
+            ErrorCode.ROOM_NOT_FOUND,
+            ErrorCode.ROOM_MEMBER_NOT_FOUND,
+            ErrorCode.FORBIDDEN,
+            ErrorCode.INVALID_INPUT_VALUE    })
+    public ApiResponse<Long> captureThief(
             @Parameter(description = "방 ID") @PathVariable Long roomId,
-            @Parameter(description = "사용자 ID") @PathVariable Long userId) {
+            @Parameter(description = "검거한 도둑의 ID") @PathVariable Long userId) {
         // TODO: 구현 필요
-        return ApiResponse.success(null);
+        Long currentPoliceId = 1L;
+
+        // 1. 검거 로직 실행
+        roomMemberService.captureThief(roomId, userId, currentPoliceId);
+
+        // 2. 해당 경찰의 현재 누적 검거 횟수 조회
+        long captureCount = roomMemberService.getPoliceCaptureCount(roomId, currentPoliceId);
+
+        return ApiResponse.success("도둑을 검거했습니다! 현재 검거 횟수: " + captureCount, captureCount);
     }
 
     @PatchMapping("/participants/{userId}/release")

--- a/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/entity/RoomMember.java
+++ b/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/entity/RoomMember.java
@@ -61,4 +61,11 @@ public class RoomMember extends BaseEntity {
     public void assignRole(Role role) {
         this.role = role;
     }
+
+    public void updateToCaught(User policeUser) {
+        this.thiefState = ThiefState.CAUGHT;
+        this.caughtByUser = policeUser;
+        this.caughtAt = LocalDateTime.now();
+    }
 }
+


### PR DESCRIPTION
**🔗 관련 이슈**
#32

---

**📌 PR 요약**
경찰이 도둑의 ID를 입력하여 검거하고, 해당 경찰의 누적 검거 횟수를 실시간으로 반환하는 기능을 구현했습니다.

---

**📑 작업 내용**
1. **RoomMember 엔티티**: 검거 상태(`CAUGHT`) 및 검거 경찰 정보를 업데이트하는 `updateToCaught` 메서드 추가
2. **RoomMemberService**: 게임 상태 및 역할군 검증 로직을 포함한 검거 비즈니스 로직 구현
3. **RoomMemberService**: 특정 경찰이 해당 방에서 잡은 도둑 수를 계산하는 카운트 로직 추가
4. **RoomMemberController**: 검거 API(/participants/{userId}/capture) 연결 및 응답 데이터 타입(`Long`) 수정

---

**💡 추가 참고 사항**
- 현재는 인증 시스템 연동 전으로 경찰 ID를 임시값(`1L`)으로 처리하고 있습니다.
- 이후 게임 종료 조건(모든 도둑 검거 등) 판정 시 `getPoliceCaptureCount` 로직을 활용할 수 있습니다.