### PR TITLE
feat/#51: 방 생성 응답에 hostId 추가

### DIFF
--- a/Hackathon-team5/src/main/java/com/example/demo/domain/room/dto/response/CreateRoomResponseDto.java
+++ b/Hackathon-team5/src/main/java/com/example/demo/domain/room/dto/response/CreateRoomResponseDto.java
@@ -14,4 +14,5 @@ import lombok.NoArgsConstructor;
 public class CreateRoomResponseDto {
 
     private Long roomId;
+    private Long hostId;
 }

--- a/Hackathon-team5/src/main/java/com/example/demo/domain/room/service/RoomService.java
+++ b/Hackathon-team5/src/main/java/com/example/demo/domain/room/service/RoomService.java
@@ -63,6 +63,7 @@ public class RoomService {
 
         return CreateRoomResponseDto.builder()
                 .roomId(savedRoom.getId())
+                .hostId(user.getId())
                 .build();
     }
 


### PR DESCRIPTION
🔗 관련 이슈
#51

📌 PR 요약
방 생성 성공 시 반환되는 데이터에 방장의 ID(hostId)를 추가하여 클라이언트 측 편의성을 개선하였습니다.

📑 작업 내용
DTO 수정

CreateRoomResponseDto 클래스에 hostId 필드를 추가하였습니다.

Swagger UI 확인을 위한 @Schema 설명을 추가하였습니다.

서비스 로직 수정

RoomService.createRoom 로직 내에서 생성된 방의 호스트 ID를 DTO에 담아 반환하도록 변경하였습니다.

💡 추가 참고 사항
기존 roomId만 반환하던 구조에서 hostId가 추가됨에 따라, 프론트엔드에서 방 생성 직후 별도의 조회 없이 방장 여부를 판단할 수 있게 되었습니다.