### PR TITLE
방 참가 추가

### DIFF
--- a/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/entity/RoomMember.java
+++ b/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/entity/RoomMember.java
@@ -71,6 +71,13 @@ public class RoomMember extends BaseEntity {
 
     public void assignRole(Role role) {
         this.role = role;
+        // 도둑 역할이면 thiefState를 ALIVE로 초기화
+        if (role == Role.THIEF) {
+            this.thiefState = ThiefState.ALIVE;
+        } else {
+            // 경찰이면 thiefState는 null로
+            this.thiefState = null;
+        }
     }
 
     public void updateToCaught(User policeUser) {

--- a/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/service/RoomMemberService.java
+++ b/Hackathon-team5/src/main/java/com/example/demo/domain/room_member/service/RoomMemberService.java
@@ -135,24 +135,52 @@ public class RoomMemberService {
                 room.getCapacityThief()
         );
 
-        // 8. RoomMember 생성 및 저장
+        // 8. 역할 선호도를 실제 역할로 변환
+        Role assignedRole = convertRolePreferenceToRole(finalRolePreference);
+
+        // 9. RoomMember 생성 및 저장
         RoomMember newMember = RoomMember.builder()
                 .room(room)
                 .user(user)
                 .joinStatus(JoinStatus.JOINED)
                 .rolePreference(finalRolePreference)
+                .role(assignedRole)  // 역할 즉시 배정
                 .isArrived(false)
                 .build();
         roomMemberRepository.save(newMember);
 
         System.out.println("방 참가 완료 - roomId: " + roomId + ", userId: " + userId + ", rolePreference: " + finalRolePreference);
 
-        return JoinRoomResponseDto.builder()
+        JoinRoomResponseDto response = JoinRoomResponseDto.builder()
                 .roomId(roomId)
                 .userId(userId)
-                .rolePreference(finalRolePreference.name())
+                .rolePreference(finalRolePreference != null ? finalRolePreference.name() : "UNKNOWN")
                 .message("방 참가에 성공했습니다.")
                 .build();
+        
+        System.out.println("응답 생성 완료: " + response);
+        System.out.println("  - roomId: " + response.getRoomId());
+        System.out.println("  - userId: " + response.getUserId());
+        System.out.println("  - rolePreference: " + response.getRolePreference());
+        
+        return response;
+    }
+
+    /**
+     * RolePreference를 실제 Role로 변환
+     */
+    private Role convertRolePreferenceToRole(RolePreference rolePreference) {
+        if (rolePreference == null) {
+            return null;
+        }
+        switch (rolePreference) {
+            case POLICE:
+                return Role.POLICE;
+            case THIEF:
+                return Role.THIEF;
+            default:
+                return null;
+        }
     }
 
     /**
@@ -165,6 +193,11 @@ public class RoomMemberService {
             Integer policeCapacity,
             Integer thiefCapacity
     ) {
+        // null 체크: rolePreference가 없으면 RANDOM으로 처리
+        if (requestedPreference == null) {
+            requestedPreference = JoinRoomRequestDto.RolePreference.RANDOM;
+        }
+
         // 현재 역할군별 인원 계산
         long currentPoliceCount = currentMembers.stream()
                 .filter(m -> m.getRolePreference() == RolePreference.POLICE)


### PR DESCRIPTION
1. 참가자는 방 참가 즉시 자신의 임시 역할 확인 가능 방장은 게임 시작 전 역할 변경 가능
2. 게임 시작 시 최종 역할 확정 + thiefState 자동 초기화3. 역할 변경 시에도 thiefState가 자동으로 올바르게 설정됨

## 🔗 관련 이슈

연관된 이슈 번호를 적어주세요. (예: #123)

---

## 📌 PR 요약

PR에 대한 간략한 설명을 작성해주세요.  
(예: 해당 변경 사항의 목적이나 주요 내용)

---

## 📑 작업 내용

작업의 세부 내용을 작성해주세요.
1. 작업 내용 1
2. 작업 내용 2
3. 작업 내용 3

---

## 스크린샷 (선택)


---

## 💡 추가 참고 사항

PR에 대해 추가적으로 논의하거나 참고해야 할 내용을 작성해주세요.
(예: 변경사항이 코드베이스에 미치는 영향, 테스트 방법 등)
